### PR TITLE
Add api-version: '1.13'

### DIFF
--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -1,5 +1,6 @@
 name: GeyserUtils
 version: '${project.version}'
+api-version: '1.13'
 main: me.zimzaza4.geyserutils.spigot.GeyserUtils
 authors:
   - zimzaza4


### PR DESCRIPTION
Fix the warn: `[16:51:38] [Server thread/WARN]: Legacy plugin GeyserUtils v1.0-SNAPSHOT does not specify an api-version.`